### PR TITLE
Feat/#5 login swagger specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 
+*.properties
+
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,61 +1,63 @@
 plugins {
-	id("org.springframework.boot") version "3.3.1"
-	id("io.spring.dependency-management") version "1.1.5"
-	kotlin("plugin.jpa") version "1.9.24"
-	kotlin("jvm") version "1.9.24"
-	kotlin("plugin.spring") version "1.9.24"
+    id("org.springframework.boot") version "3.3.1"
+    id("io.spring.dependency-management") version "1.1.5"
+    kotlin("plugin.jpa") version "1.9.24"
+    kotlin("jvm") version "1.9.24"
+    kotlin("plugin.spring") version "1.9.24"
 }
 
 group = "bingsoochef"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom(configurations.annotationProcessor.get())
-	}
+    compileOnly {
+        extendsFrom(configurations.annotationProcessor.get())
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-	// web
-	implementation("org.springframework.boot:spring-boot-starter-web")
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
-	// thymeleaf
-	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
-	implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
+    // thymeleaf
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
 
-	// security
-	implementation("org.springframework.boot:spring-boot-starter-security")
-	testImplementation("org.springframework.security:spring-security-test")
+    // security
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.security:spring-security-test")
 
-	// database
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-//	runtimeOnly("com.mysql:mysql-connector-j")
+    // database
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("com.mysql:mysql-connector-j")
 
-	// test
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    // test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict")
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthController.kt
@@ -1,0 +1,33 @@
+package bingsoochef.bingsoochef.auth
+
+import bingsoochef.bingsoochef.presentation.req.LoginRequest
+import bingsoochef.bingsoochef.presentation.res.LoginResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/users")
+class AuthController {
+
+    @Operation(summary = "Login")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Login Success")
+    )
+    @PostMapping("/basic")
+    fun login(
+        @RequestBody loginRequest: LoginRequest
+    ): ResponseEntity<LoginResponse> {
+        val response = LoginResponse("accessToken", 3600, "refreshToken", 3600)
+
+        return ResponseEntity.ok()
+            .body(response)
+    }
+
+    
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthController.kt
@@ -3,13 +3,11 @@ package bingsoochef.bingsoochef.auth
 import bingsoochef.bingsoochef.presentation.req.LoginRequest
 import bingsoochef.bingsoochef.presentation.res.LoginResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/users")
@@ -29,5 +27,18 @@ class AuthController {
             .body(response)
     }
 
-    
+    @Operation(summary = "Kakao OAuth")
+    @ApiResponses(
+        ApiResponse(
+            responseCode = "SEE OTHER",
+            headers = [Header(name = "Location", description = "Redirect URL")],
+            description = "Kakao OAuth로 Redirect"
+        )
+    )
+    @GetMapping("/oauth/kakao")
+    fun kakaoOauth(): ResponseEntity<Void> {
+        return ResponseEntity.status(303)
+            .header("Location", "")
+            .build()
+    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthController.kt
@@ -2,23 +2,15 @@ package bingsoochef.bingsoochef.auth
 
 import bingsoochef.bingsoochef.presentation.req.LoginRequest
 import bingsoochef.bingsoochef.presentation.res.LoginResponse
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.headers.Header
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/users")
-class AuthController {
+class AuthController : AuthControllerInterface {
 
-    @Operation(summary = "Login")
-    @ApiResponses(
-        ApiResponse(responseCode = "200", description = "Login Success")
-    )
     @PostMapping("/basic")
-    fun login(
+    override fun login(
         @RequestBody loginRequest: LoginRequest
     ): ResponseEntity<LoginResponse> {
         val response = LoginResponse("accessToken", 3600, "refreshToken", 3600)
@@ -27,16 +19,22 @@ class AuthController {
             .body(response)
     }
 
-    @Operation(summary = "Kakao OAuth")
-    @ApiResponses(
-        ApiResponse(
-            responseCode = "SEE OTHER",
-            headers = [Header(name = "Location", description = "Redirect URL")],
-            description = "Kakao OAuth로 Redirect"
-        )
-    )
     @GetMapping("/oauth/kakao")
-    fun kakaoOauth(): ResponseEntity<Void> {
+    override fun kakaoOauth(): ResponseEntity<Void> {
+        return ResponseEntity.status(303)
+            .header("Location", "")
+            .build()
+    }
+
+    @GetMapping("/oauth/google")
+    override fun googleOauth(): ResponseEntity<Void> {
+        return ResponseEntity.status(303)
+            .header("Location", "")
+            .build()
+    }
+
+    @GetMapping("/oauth/naver")
+    override fun naverOauth(): ResponseEntity<Void> {
         return ResponseEntity.status(303)
             .header("Location", "")
             .build()

--- a/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/auth/AuthControllerInterface.kt
@@ -1,0 +1,47 @@
+package bingsoochef.bingsoochef.auth
+
+import bingsoochef.bingsoochef.presentation.req.LoginRequest
+import bingsoochef.bingsoochef.presentation.res.LoginResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.ResponseEntity
+
+interface AuthControllerInterface {
+    @Operation(summary = "Login")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Login Success")
+    )
+    fun login(loginRequest: LoginRequest): ResponseEntity<LoginResponse>
+
+    @Operation(summary = "Kakao OAuth")
+    @ApiResponses(
+        ApiResponse(
+            responseCode = "SEE OTHER",
+            headers = [Header(name = "Location", description = "Redirect URL")],
+            description = "Kakao OAuth로 Redirect"
+        )
+    )
+    fun kakaoOauth(): ResponseEntity<Void>
+
+    @Operation(summary = "Google OAuth")
+    @ApiResponses(
+        ApiResponse(
+            responseCode = "SEE OTHER",
+            headers = [Header(name = "Location", description = "Redirect URL")],
+            description = "Google OAuth로 Redirect"
+        )
+    )
+    fun googleOauth(): ResponseEntity<Void>
+
+    @Operation(summary = "Naver OAuth")
+    @ApiResponses(
+        ApiResponse(
+            responseCode = "SEE OTHER",
+            headers = [Header(name = "Location", description = "Redirect URL")],
+            description = "Naver OAuth로 Redirect"
+        )
+    )
+    fun naverOauth(): ResponseEntity<Void>
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/auth/req/LoginRequest.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/auth/req/LoginRequest.kt
@@ -1,0 +1,7 @@
+package bingsoochef.bingsoochef.presentation.req
+
+data class LoginRequest(
+    val email: String,
+    val password: String
+) {
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/auth/res/LoginResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/auth/res/LoginResponse.kt
@@ -1,0 +1,8 @@
+package bingsoochef.bingsoochef.presentation.res
+
+data class LoginResponse(
+    val accessToken: String,
+    val expiresIn: Int,
+    val refreshToken: String,
+    val refreshTokenExpiresIn: Int
+)


### PR DESCRIPTION
### ✨ 작업 내용

---
- 로그인 관련 API 명세
  - 카카오 로그인
  - Naver 로그인
  - 구글 로그인

### ✨ 참고 사항

---
- CallBack함수는 명세하지 않습니다.
- 추후 Security활용 시 일반 로그인 명세가 삭제될 수 있습니다.


### ⏰ 현재 버그

---

### ✏ Git Close

closes #5 
