### PR TITLE
Feat/#4 swagger specific

### DIFF
--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -17,7 +17,7 @@ class BingsooController : BingsooControllerInterface {
     }
 
     @GetMapping("/{bingsoo-id}")
-    override fun getBingsoo(@PathVariable(value = "bingsoo-id") bingsooId: Long): ResponseEntity<BingsooDetailResponse> {
+    override fun getBingsoo(@PathVariable(value = "bingsoo-id") bingsooId: Long): ResponseEntity<BingsooResponse> {
         TODO()
     }
 

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -2,7 +2,6 @@ package bingsoochef.bingsoochef.bingsoo.presentation
 
 import bingsoochef.bingsoochef.bingsoo.presentation.req.CreateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.req.UpdateBingsooRequest
-import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooDetailResponse
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooControllerInterface.kt
@@ -34,10 +34,10 @@ interface BingsooControllerInterface {
         summary = "빙수 조회 API",
         description = "bingsoo id를 통해 자신 혹은 다른 사용자의 빙수를 조회합니다."
     )
-    @ApiResponse(responseCode = "200", description = "빙수와 빙수가 가진 토핑 배열 반환",
-        content = [Content(mediaType = "application/json", array = (ArraySchema(schema = Schema(implementation = BingsooDetailResponse::class))))]
+    @ApiResponse(responseCode = "200", description = "조회한 빙수 반환",
+        content = [Content(mediaType = "application/json", array = (ArraySchema(schema = Schema(implementation = BingsooResponse::class))))]
     )
-    fun getBingsoo(@PathVariable(value = "bingsoo_id") bingsooId: Long): ResponseEntity<BingsooDetailResponse>
+    fun getBingsoo(@PathVariable(value = "bingsoo_id") bingsooId: Long): ResponseEntity<BingsooResponse>
 
 
     @Operation(

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooControllerInterface.kt
@@ -2,7 +2,6 @@ package bingsoochef.bingsoochef.bingsoo.presentation
 
 import bingsoochef.bingsoochef.bingsoo.presentation.req.CreateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.req.UpdateBingsooRequest
-import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooDetailResponse
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/res/BingsooDetailResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/res/BingsooDetailResponse.kt
@@ -1,6 +1,0 @@
-package bingsoochef.bingsoochef.bingsoo.presentation.res
-
-data class BingsooDetailResponse (
-    val bingsoo: BingsooDto,
-    val toppings: List<ToppingAbstractDto>
-)

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingController.kt
@@ -7,6 +7,8 @@ import bingsoochef.bingsoochef.toppping.presentation.res.QuizResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.ToppingPageResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.ToppingResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.TryResultResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -20,7 +22,9 @@ class ToppingController : ToppingControllerInterface {
     }
 
     @GetMapping("")
-    override fun getToppingPage(@RequestParam(value = "b") bingsooId: Long, @RequestParam(value = "p") page: Int): ResponseEntity<ToppingPageResponse> {
+    override fun getToppingPage(
+        @RequestParam(value = "b") bingsooId: Long,
+        @PageableDefault(page = 0, size = 8) pageable: Pageable ): ResponseEntity<ToppingPageResponse> {
         TODO()
     }
 

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingController.kt
@@ -4,6 +4,7 @@ import bingsoochef.bingsoochef.toppping.presentation.req.CreateToppingRequest
 import bingsoochef.bingsoochef.toppping.presentation.req.RegisterCommentRequest
 import bingsoochef.bingsoochef.toppping.presentation.req.TryQuizRequest
 import bingsoochef.bingsoochef.toppping.presentation.res.QuizResponse
+import bingsoochef.bingsoochef.toppping.presentation.res.ToppingPageResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.ToppingResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.TryResultResponse
 import org.springframework.http.ResponseEntity
@@ -15,6 +16,11 @@ class ToppingController : ToppingControllerInterface {
 
     @PostMapping
     override fun createTopping(@RequestBody request: CreateToppingRequest): ResponseEntity<ToppingResponse> {
+        TODO()
+    }
+
+    @GetMapping("")
+    override fun getToppingPage(@RequestParam(value = "b") bingsooId: Long, @RequestParam(value = "p") page: Int): ResponseEntity<ToppingPageResponse> {
         TODO()
     }
 

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingControllerInterface.kt
@@ -5,6 +5,7 @@ import bingsoochef.bingsoochef.toppping.presentation.req.RegisterCommentRequest
 import bingsoochef.bingsoochef.toppping.presentation.req.TryQuizRequest
 import bingsoochef.bingsoochef.toppping.presentation.res.QuizResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.ToppingResponse
+import bingsoochef.bingsoochef.toppping.presentation.res.ToppingPageResponse
 import bingsoochef.bingsoochef.toppping.presentation.res.TryResultResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "Topping", description = "토핑 API")
 interface ToppingControllerInterface {
@@ -33,6 +35,18 @@ interface ToppingControllerInterface {
     ])
     fun createTopping(@RequestBody request: CreateToppingRequest): ResponseEntity<ToppingResponse>
 
+    @Operation(
+        summary = "토핑 목록 조회 API",
+        description = "bingsoo id를 가진 빙수의 토핑들을 조회합니다.<br>" +
+                "토핑은 8의 크기로 페이지네이션을 적용해 반환되며, 전체 페이지 범위는 0 ~ total page number(totalPage)입니다.<br>" +
+                "현재 페이지 번호가 전체 페이지 범위를 벗어날 경우 성공 응답에도 toppings의 정보가 반환되지 않습니다."
+    )
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "조회한 토핑 목록 반환",
+            content = [Content(mediaType = "application/json", array = (ArraySchema(schema = Schema(implementation = ToppingPageResponse::class))))]),
+        ApiResponse(responseCode = "404", description = "존재하지 않는 빙수임", content = [Content()])
+    ])
+    fun getToppingPage(@RequestParam(value = "b") bingsooId: Long, @RequestParam(value = "p") page: Int): ResponseEntity<ToppingPageResponse>
 
     @Operation(
         summary = "토핑 조회 API",

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingControllerInterface.kt
@@ -14,6 +14,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
@@ -47,7 +50,9 @@ interface ToppingControllerInterface {
             content = [Content(mediaType = "application/json", array = (ArraySchema(schema = Schema(implementation = ToppingPageResponse::class))))]),
         ApiResponse(responseCode = "404", description = "존재하지 않는 빙수임", content = [Content()])
     ])
-    fun getToppingPage(@RequestParam(value = "b") bingsooId: Long, @RequestParam(value = "p") page: Int): ResponseEntity<ToppingPageResponse>
+    fun getToppingPage(
+        @RequestParam(value = "b") bingsooId: Long,
+        @PageableDefault(page = 0, size = 8) @ParameterObject pageable: Pageable): ResponseEntity<ToppingPageResponse>
 
     @Operation(
         summary = "토핑 조회 API",

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/ToppingControllerInterface.kt
@@ -38,6 +38,7 @@ interface ToppingControllerInterface {
     @Operation(
         summary = "토핑 목록 조회 API",
         description = "bingsoo id를 가진 빙수의 토핑들을 조회합니다.<br>" +
+                "쿼리 파라미터인 b는 bingsoo id, p는 현재 페이지 번호입니다.<br>" +
                 "토핑은 8의 크기로 페이지네이션을 적용해 반환되며, 전체 페이지 범위는 0 ~ total page number(totalPage)입니다.<br>" +
                 "현재 페이지 번호가 전체 페이지 범위를 벗어날 경우 성공 응답에도 toppings의 정보가 반환되지 않습니다."
     )

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingAbstractDto.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingAbstractDto.kt
@@ -1,4 +1,4 @@
-package bingsoochef.bingsoochef.bingsoo.presentation.res
+package bingsoochef.bingsoochef.toppping.presentation.res
 
 data class ToppingAbstractDto (
     val toppingId: Long,

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
@@ -3,5 +3,5 @@ package bingsoochef.bingsoochef.toppping.presentation.res
 class ToppingPageResponse(
     val currPage: Int,
     val totalPage: Int,
-    val toppings: List<ToppingDto>
+    val toppings: List<ToppingAbstractDto>
 )

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
@@ -3,5 +3,6 @@ package bingsoochef.bingsoochef.toppping.presentation.res
 data class ToppingPageResponse(
     val currPage: Int,
     val totalPage: Int,
+    val totalElements: Int,
     val toppings: List<ToppingAbstractDto>
 )

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
@@ -1,0 +1,7 @@
+package bingsoochef.bingsoochef.toppping.presentation.res
+
+class ToppingPageResponse(
+    val currPage: Int,
+    val totalPage: Int,
+    val toppings: List<ToppingDto>
+)

--- a/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/toppping/presentation/res/ToppingPageResponse.kt
@@ -1,6 +1,6 @@
 package bingsoochef.bingsoochef.toppping.presentation.res
 
-class ToppingPageResponse(
+data class ToppingPageResponse(
     val currPage: Int,
     val totalPage: Int,
     val toppings: List<ToppingAbstractDto>


### PR DESCRIPTION
### ✨ 작업 내용

- 빙수와 토핑 목록 조회에 대한 API를 분리하였습니다.
- 토핑 조회 시 페이지네이션을 적용하였습니다.
---

### ✨ 참고 사항
- 쿼리 파라미터의 경우 URL에 직접 노출되는 것을 고려하여 파라미터의 이름을 약어로 작성하였습니다.

---

### ⏰ 현재 버그

x

---


### ✏ Git Close
x