### PR TITLE
Feat/#3 bingsoo api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,11 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")
+	testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
+	testImplementation("io.kotest:kotest-property-jvm:5.9.1")
+	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+	testImplementation("io.mockk:mockk:1.13.12")
 
 	// swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
@@ -33,4 +33,9 @@ class BingsooService(
 
         return bingsoo
     }
+
+    fun getBingsoo(bingsooId: Long): Bingsoo {
+        return bingsooRepository.findById(bingsooId)
+            .orElseThrow{ NotFoundException("존재하지 않는 빙수입니다.") }
+    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
@@ -35,6 +35,7 @@ class BingsooService(
         return bingsoo
     }
 
+    @Transactional(readOnly = true)
     fun getBingsoo(bingsooId: Long): Bingsoo {
         return bingsooRepository.findById(bingsooId)
             .orElseThrow{ NotFoundException("존재하지 않는 빙수입니다.") }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
@@ -12,7 +12,8 @@ import org.springframework.stereotype.Service
 @Transactional
 class BingsooService(
     var userRepository: UserRepository,
-    var bingsooRepository: BingsooRepository) {
+    var bingsooRepository: BingsooRepository
+) {
 
     fun createBingsoo(command: CreateBingsooCommand): Bingsoo {
         var user: User = userRepository.findById(command.userId)

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
@@ -23,4 +23,14 @@ class BingsooService(
 
         return bingsoo
     }
+
+    fun updateBingsoo(command: UpdateBingsooCommand): Bingsoo {
+        val bingsoo = userRepository.findById(command.userId)
+            .orElseThrow{ NotFoundException("존재하지 않는 사용자입니다.") }
+            .bingsoo
+
+        bingsoo.updateTaste(taste = command.taste)
+
+        return bingsoo
+    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
@@ -1,0 +1,26 @@
+package bingsoochef.bingsoochef.bingsoo.application
+
+import bingsoochef.bingsoochef.bingsoo.domain.Bingsoo
+import bingsoochef.bingsoochef.bingsoo.persistence.BingsooRepository
+import bingsoochef.bingsoochef.global.error.NotFoundException
+import bingsoochef.bingsoochef.user.domain.User
+import bingsoochef.bingsoochef.user.persistence.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+@Transactional
+class BingsooService(
+    var userRepository: UserRepository,
+    var bingsooRepository: BingsooRepository) {
+
+    fun createBingsoo(command: CreateBingsooCommand): Bingsoo {
+        var user: User = userRepository.findById(command.userId)
+            .orElseThrow{ NotFoundException("존재하지 않는 사용자입니다.") }
+
+        val bingsoo: Bingsoo = bingsooRepository.save(Bingsoo(taste = command.taste))
+        // TODO("User에 Bingsoo 매핑")
+
+        return bingsoo
+    }
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/BingsooService.kt
@@ -5,8 +5,8 @@ import bingsoochef.bingsoochef.bingsoo.persistence.BingsooRepository
 import bingsoochef.bingsoochef.global.error.NotFoundException
 import bingsoochef.bingsoochef.user.domain.User
 import bingsoochef.bingsoochef.user.persistence.UserRepository
-import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/CreateBingsooCommand.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/CreateBingsooCommand.kt
@@ -5,5 +5,4 @@ import bingsoochef.bingsoochef.bingsoo.domain.Taste
 data class CreateBingsooCommand (
     val userId: Long,
     val taste: Taste
-) {
-}
+)

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/CreateBingsooCommand.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/CreateBingsooCommand.kt
@@ -1,0 +1,9 @@
+package bingsoochef.bingsoochef.bingsoo.application
+
+import bingsoochef.bingsoochef.bingsoo.domain.Taste
+
+data class CreateBingsooCommand (
+    val userId: Long,
+    val taste: Taste
+) {
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/UpdateBingsooCommand.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/UpdateBingsooCommand.kt
@@ -3,6 +3,6 @@ package bingsoochef.bingsoochef.bingsoo.application
 import bingsoochef.bingsoochef.bingsoo.domain.Taste
 
 data class UpdateBingsooCommand(
-    val bingsooId: Long,
+    val userId: Long,
     val taste: Taste
 )

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/UpdateBingsooCommand.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/application/UpdateBingsooCommand.kt
@@ -1,0 +1,8 @@
+package bingsoochef.bingsoochef.bingsoo.application
+
+import bingsoochef.bingsoochef.bingsoo.domain.Taste
+
+data class UpdateBingsooCommand(
+    val bingsooId: Long,
+    val taste: Taste
+)

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Bingsoo.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Bingsoo.kt
@@ -13,6 +13,10 @@ class Bingsoo(
     @Enumerated(EnumType.STRING)
     var taste: Taste
 ) {
+    fun updateTaste(taste: Taste) {
+        this.taste = taste
+    }
+
     override fun equals(other: Any?): Boolean {
         if (other !is Bingsoo) return false
         if (this === other) return true

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Taste.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Taste.kt
@@ -1,16 +1,6 @@
 package bingsoochef.bingsoochef.bingsoo.domain
 
-import com.fasterxml.jackson.annotation.JsonCreator
-
 enum class Taste {
     STRAWBERRY, CHOCO, CONDENSED_MILK, MATCHA, MANGO, MINT_CHOCO;
 
-//    companion object {
-//        @JsonCreator
-//        @JvmStatic
-//        fun fromValue(value: String): Taste {
-//            return entries.find { it.name.equals(value, ignoreCase = true) }
-//                ?: throw IllegalArgumentException("'$value'는 '$entries' 중에 존재하지 않습니다.")
-//        }
-//    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Taste.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Taste.kt
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonCreator
 enum class Taste {
     STRAWBERRY, CHOCO, CONDENSED_MILK, MATCHA, MANGO, MINT_CHOCO;
 
-    companion object {
-        @JsonCreator
-        @JvmStatic
-        fun fromValue(value: String): Taste {
-            return entries.find { it.name.equals(value, ignoreCase = true) }
-                ?: throw IllegalArgumentException("'$value'는 '$entries' 중에 존재하지 않습니다.")
-        }
-    }
+//    companion object {
+//        @JsonCreator
+//        @JvmStatic
+//        fun fromValue(value: String): Taste {
+//            return entries.find { it.name.equals(value, ignoreCase = true) }
+//                ?: throw IllegalArgumentException("'$value'는 '$entries' 중에 존재하지 않습니다.")
+//        }
+//    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Taste.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/domain/Taste.kt
@@ -1,5 +1,16 @@
 package bingsoochef.bingsoochef.bingsoo.domain
 
+import com.fasterxml.jackson.annotation.JsonCreator
+
 enum class Taste {
-    STRAWBERRY, CHOCO, CONDENSED_MILK, MATCHA, MANGO, MINT_CHOCO
+    STRAWBERRY, CHOCO, CONDENSED_MILK, MATCHA, MANGO, MINT_CHOCO;
+
+    companion object {
+        @JsonCreator
+        @JvmStatic
+        fun fromValue(value: String): Taste {
+            return entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("'$value'는 '$entries' 중에 존재하지 않습니다.")
+        }
+    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -1,19 +1,37 @@
 package bingsoochef.bingsoochef.bingsoo.presentation
 
+import bingsoochef.bingsoochef.bingsoo.application.BingsooService
+import bingsoochef.bingsoochef.bingsoo.application.CreateBingsooCommand
 import bingsoochef.bingsoochef.bingsoo.presentation.req.CreateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.req.UpdateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooDetailResponse
+import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooDto
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooResponse
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController()
 @RequestMapping("/users/bingsoo")
-class BingsooController : BingsooControllerInterface {
+class BingsooController(
+    private val bingsooService : BingsooService
+): BingsooControllerInterface {
 
     @PostMapping
-    override fun createBingsoo(@RequestBody request: CreateBingsooRequest): ResponseEntity<BingsooResponse> {
-        TODO()
+    override fun createBingsoo(@RequestBody request: CreateBingsooRequest) : ResponseEntity<BingsooResponse> {
+        // TODO("user id를 access token에서 가져오도록 수정")
+        val userId = 1L
+
+        val createCommand = CreateBingsooCommand(
+            userId,
+            request.taste
+        )
+
+        val bingsoo = bingsooService.createBingsoo(createCommand)
+        val bingsooDto = BingsooDto.from(bingsoo)
+        val bingsooResponse = BingsooResponse.of(bingsooDto)
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(bingsooResponse)
     }
 
     @GetMapping("/{bingsoo-id}")

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -2,6 +2,7 @@ package bingsoochef.bingsoochef.bingsoo.presentation
 
 import bingsoochef.bingsoochef.bingsoo.application.BingsooService
 import bingsoochef.bingsoochef.bingsoo.application.CreateBingsooCommand
+import bingsoochef.bingsoochef.bingsoo.application.UpdateBingsooCommand
 import bingsoochef.bingsoochef.bingsoo.presentation.req.CreateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.req.UpdateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooDetailResponse
@@ -41,6 +42,18 @@ class BingsooController(
 
     @PatchMapping()
     override fun updateBingsoo(@RequestBody request: UpdateBingsooRequest): ResponseEntity<BingsooResponse> {
-        TODO()
+        // TODO("user id를 access token에서 가져오도록 수정")
+        val userId = 1L
+
+        val updateCommand = UpdateBingsooCommand(
+            userId,
+            request.taste
+        )
+
+        val bingsoo = bingsooService.updateBingsoo(updateCommand)
+        val bingsooDto = BingsooDto.from(bingsoo)
+        val bingsooResponse = BingsooResponse.of(bingsooDto)
+
+        return ResponseEntity.status(HttpStatus.OK).body(bingsooResponse)
     }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -36,7 +36,11 @@ class BingsooController(
 
     @GetMapping("/{bingsoo-id}")
     override fun getBingsoo(@PathVariable(value = "bingsoo-id") bingsooId: Long): ResponseEntity<BingsooResponse> {
-        TODO()
+        val bingsoo = bingsooService.getBingsoo(bingsooId)
+        val bingsooDto = BingsooDto.from(bingsoo)
+        val bingsooResponse = BingsooResponse.of(bingsooDto)
+
+        return ResponseEntity.status(HttpStatus.OK).body(bingsooResponse)
     }
 
     @PatchMapping()

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -7,9 +7,12 @@ import bingsoochef.bingsoochef.bingsoo.presentation.req.CreateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.req.UpdateBingsooRequest
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooDto
 import bingsoochef.bingsoochef.bingsoo.presentation.res.BingsooResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+
+private val logger = KotlinLogging.logger {}
 
 @RestController()
 @RequestMapping("/users/bingsoo")

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -20,7 +20,7 @@ class BingsooController(
     @PostMapping
     override fun createBingsoo(@RequestBody request: CreateBingsooRequest) : ResponseEntity<BingsooResponse> {
         // TODO("user id를 access token에서 가져오도록 수정")
-        val userId = 1L
+        val userId = request.userId
 
         val createCommand = CreateBingsooCommand(
             userId,
@@ -46,7 +46,7 @@ class BingsooController(
     @PatchMapping()
     override fun updateBingsoo(@RequestBody request: UpdateBingsooRequest): ResponseEntity<BingsooResponse> {
         // TODO("user id를 access token에서 가져오도록 수정")
-        val userId = 1L
+        val userId = request.userId
 
         val updateCommand = UpdateBingsooCommand(
             userId,

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooController.kt
@@ -25,10 +25,7 @@ class BingsooController(
         // TODO("user id를 access token에서 가져오도록 수정")
         val userId = request.userId
 
-        val createCommand = CreateBingsooCommand(
-            userId,
-            request.taste
-        )
+        val createCommand = CreateBingsooCommand(userId, request.taste)
 
         val bingsoo = bingsooService.createBingsoo(createCommand)
         val bingsooDto = BingsooDto.from(bingsoo)
@@ -51,10 +48,7 @@ class BingsooController(
         // TODO("user id를 access token에서 가져오도록 수정")
         val userId = request.userId
 
-        val updateCommand = UpdateBingsooCommand(
-            userId,
-            request.taste
-        )
+        val updateCommand = UpdateBingsooCommand(userId, request.taste)
 
         val bingsoo = bingsooService.updateBingsoo(updateCommand)
         val bingsooDto = BingsooDto.from(bingsoo)

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooControllerInterface.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/BingsooControllerInterface.kt
@@ -19,7 +19,8 @@ interface BingsooControllerInterface {
 
     @Operation(
         summary = "빙수 생성 API",
-        description = "주어진 access token 속 user id를 가진 사용자에게 빙수를 생성합니다."
+        description = "주어진 access token 속 user id를 가진 사용자에게 빙수를 생성합니다.<br>" +
+                "현재 Request body의 user id는 로그인이 적용되기 전까지 사용하는 임시값입니다."
     )
     @ApiResponses(value = [
         ApiResponse(responseCode = "201", description = "생성된 빙수 반환",
@@ -41,7 +42,8 @@ interface BingsooControllerInterface {
 
     @Operation(
         summary = "빙수 수정 API",
-        description = "주어진 access token 속 bingsoo id를 가진 빙수의 맛을 요청한 값으로 수정합니다."
+        description = "주어진 access token 속 bingsoo id를 가진 빙수의 맛을 요청한 값으로 수정합니다." +
+                "현재 Request body의 user id는 로그인이 적용되기 전까지 사용하는 임시값입니다."
     )
     @ApiResponse(responseCode = "200", description = "수정된 빙수 반환",
         content = [Content(mediaType = "application/json", array = (ArraySchema(schema = Schema(implementation = BingsooResponse::class))))]

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/req/CreateBingsooRequest.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/req/CreateBingsooRequest.kt
@@ -3,5 +3,6 @@ package bingsoochef.bingsoochef.bingsoo.presentation.req
 import bingsoochef.bingsoochef.bingsoo.domain.Taste
 
 data class CreateBingsooRequest (
-    val taste: Taste
+    val taste: Taste,
+    val userId: Long
 )

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/req/UpdateBingsooRequest.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/req/UpdateBingsooRequest.kt
@@ -3,5 +3,6 @@ package bingsoochef.bingsoochef.bingsoo.presentation.req
 import bingsoochef.bingsoochef.bingsoo.domain.Taste
 
 data class UpdateBingsooRequest(
-    val taste: Taste
+    val taste: Taste,
+    val userId: Long
 )

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/res/BingsooDto.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/res/BingsooDto.kt
@@ -1,8 +1,15 @@
 package bingsoochef.bingsoochef.bingsoo.presentation.res
 
+import bingsoochef.bingsoochef.bingsoo.domain.Bingsoo
 import bingsoochef.bingsoochef.bingsoo.domain.Taste
 
 data class BingsooDto(
     val bingsooId: Long,
     val taste: Taste
-)
+) {
+    companion object {
+        fun from(bingsoo: Bingsoo): BingsooDto {
+            return BingsooDto(bingsoo.id!!, bingsoo.taste)
+        }
+    }
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/res/BingsooResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/bingsoo/presentation/res/BingsooResponse.kt
@@ -1,5 +1,11 @@
-package bingsoochef.bingsoochef.bingsoo.presentation.res;
+package bingsoochef.bingsoochef.bingsoo.presentation.res
 
-data class BingsooResponse (
+data class BingsooResponse(
     val bingsoo: BingsooDto
-)
+) {
+    companion object {
+        fun of(bingsooDto: BingsooDto): BingsooResponse {
+            return BingsooResponse(bingsooDto)
+        }
+    }
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/CustomException.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/CustomException.kt
@@ -1,0 +1,22 @@
+package bingsoochef.bingsoochef.global.error
+
+import org.springframework.http.HttpStatus
+
+open class CustomException : RuntimeException {
+
+    val httpStatus: HttpStatus
+    override val message: String
+        get() = super.message ?: ""
+
+    constructor(message: String) : super(message) {
+        this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+    }
+
+    constructor(message: String, httpStatus: HttpStatus) : super(message) {
+        this.httpStatus = httpStatus
+    }
+
+    fun getStatusCode() : Int {
+        return httpStatus.value()
+    }
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/ErrorResponse.kt
@@ -3,5 +3,5 @@ package bingsoochef.bingsoochef.global.error
 
 class ErrorResponse(
     val statusCode: Int,
-    val message: String
-) {}
+    val message: String?
+)

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/ErrorResponse.kt
@@ -1,0 +1,7 @@
+package bingsoochef.bingsoochef.global.error
+
+
+class ErrorResponse(
+    val statusCode: Int,
+    val message: String
+) {}

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/ExceptionHandler.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/ExceptionHandler.kt
@@ -1,0 +1,29 @@
+package bingsoochef.bingsoochef.global.error
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class ExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity<ErrorResponse>(
+            ErrorResponse(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다."),HttpStatus.BAD_REQUEST)
+    }
+
+    @ExceptionHandler(CustomException::class)
+    fun handleCustomException(e: CustomException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity<ErrorResponse>(
+            ErrorResponse(e.getStatusCode(), e.message),e.httpStatus)
+    }
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFoundException(e: NotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity<ErrorResponse>(
+            ErrorResponse(e.getStatusCode(), e.message),e.httpStatus)
+    }
+
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/ExceptionHandler.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/ExceptionHandler.kt
@@ -11,7 +11,7 @@ class ExceptionHandler {
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
         return ResponseEntity<ErrorResponse>(
-            ErrorResponse(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다."),HttpStatus.BAD_REQUEST)
+            ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.message),HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(CustomException::class)

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/ExceptionHandler.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/ExceptionHandler.kt
@@ -1,9 +1,17 @@
 package bingsoochef.bingsoochef.global.error
 
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.json.JsonParseException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+
+private val logger = KotlinLogging.logger {}
 
 @RestControllerAdvice
 class ExceptionHandler {
@@ -26,4 +34,30 @@ class ExceptionHandler {
             ErrorResponse(e.getStatusCode(), e.message),e.httpStatus)
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+        val message: String = when (val cause = e.cause) {
+            is JsonParseException -> "올바른 JSON 형식이 아닙니다."
+
+            is JsonMappingException -> {
+                val path = cause.path.joinToString("/") { it.fieldName }
+                when (cause) {
+                    is InvalidFormatException -> {
+                        when {
+                            cause.targetType.isEnum ->
+                                "$path 은 Enum으로, ${cause.targetType.enumConstants.joinToString(", ") { (it as Enum<*>).name }} 중 하나여야 합니다."
+                            else -> "$path 의 타입은 ${cause.targetType.simpleName}이어야 합니다."
+                        }
+                    }
+                    is MismatchedInputException -> "$path 을/를 ${cause.targetType.simpleName}에 매핑할 수 없습니다."
+                    else -> "JSON 매핑에 실패하였습니다."
+                }
+            }
+
+            else -> "HTTP 메시지를 읽는 중 알 수 없는 오류가 발생하였습니다."
+        }
+
+        return ResponseEntity<ErrorResponse>(
+            ErrorResponse(HttpStatus.BAD_REQUEST.value(), message), HttpStatus.BAD_REQUEST)
+    }
 }

--- a/src/main/kotlin/bingsoochef/bingsoochef/global/error/NotFoundException.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/global/error/NotFoundException.kt
@@ -1,0 +1,6 @@
+package bingsoochef.bingsoochef.global.error
+
+import org.springframework.http.HttpStatus
+
+class NotFoundException(message: String) : CustomException(message, HttpStatus.NOT_FOUND) {
+}

--- a/src/main/kotlin/bingsoochef/bingsoochef/user/persistence/UserRepository.kt
+++ b/src/main/kotlin/bingsoochef/bingsoochef/user/persistence/UserRepository.kt
@@ -1,0 +1,9 @@
+package bingsoochef.bingsoochef.user.persistence
+
+import bingsoochef.bingsoochef.user.domain.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+}

--- a/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
+++ b/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
@@ -5,11 +5,14 @@ import bingsoochef.bingsoochef.bingsoo.domain.Taste
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 
-@SpringBootTest
-class JpaRepositoryTest(
-    private var bingsooRepository : BingsooRepository
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class JpaRepositoryTest @Autowired constructor(
+     private var bingsooRepository : BingsooRepository
 ) : BehaviorSpec({
 
     Given("ID가 없는 빙수가 주어지고") {

--- a/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
+++ b/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
@@ -1,0 +1,27 @@
+package bingsoochef.bingsoochef.bingsoo.persistence
+
+import bingsoochef.bingsoochef.bingsoo.domain.Bingsoo
+import bingsoochef.bingsoochef.bingsoo.domain.Taste
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class JpaRepositoryTest(
+    private var bingsooRepository : BingsooRepository
+) : BehaviorSpec({
+
+    Given("ID가 없는 빙수가 주어지고") {
+        var givenBingsoo = Bingsoo(null, Taste.valueOf("STRAWBERRY"))
+
+        When("빙수를 저장했을 때") {
+            var resultBingsoo = bingsooRepository.save(givenBingsoo)
+
+            Then("ID를 가지는 주어진 정보의 빙수가 생성된다.") {
+                resultBingsoo.id shouldNotBe null
+                resultBingsoo.taste shouldBe givenBingsoo.taste
+            }
+        }
+    }
+})

--- a/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
+++ b/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
@@ -8,22 +8,61 @@ import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.repository.findByIdOrNull
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class JpaRepositoryTest @Autowired constructor(
-     private var bingsooRepository : BingsooRepository
+    private var bingsooRepository : BingsooRepository
 ) : BehaviorSpec({
 
     Given("ID가 없는 빙수가 주어지고") {
-        var givenBingsoo = Bingsoo(null, Taste.valueOf("STRAWBERRY"))
+        val givenBingsoo = Bingsoo(null, Taste.valueOf("STRAWBERRY"))
 
-        When("빙수를 저장했을 때") {
-            var resultBingsoo = bingsooRepository.save(givenBingsoo)
+        When("빙수를 저장해 ID가 생겼을 때") {
+            val resultId = bingsooRepository.save(givenBingsoo).id
 
-            Then("ID를 가지는 주어진 정보의 빙수가 생성된다.") {
-                resultBingsoo.id shouldNotBe null
-                resultBingsoo.taste shouldBe givenBingsoo.taste
+            Then("빙수를 다시 조회할 수 있다.") {
+                bingsooRepository.findByIdOrNull(resultId) shouldNotBe null
+            }
+        }
+    }
+
+    Given("새로운 빙수를 저장하고") {
+        val givenBingsoo = Bingsoo(null, Taste.valueOf("STRAWBERRY"))
+        val savedBingsoo = bingsooRepository.save(givenBingsoo)
+
+        When("빙수를 다시 조회했을 때") {
+            val foundedBingsoo = bingsooRepository.findByIdOrNull(savedBingsoo.id)!!
+
+            Then("equals의 reflexive 테스트") {
+                givenBingsoo.equals(givenBingsoo) shouldBe true
+                savedBingsoo.equals(savedBingsoo) shouldBe true
+                foundedBingsoo.equals(foundedBingsoo) shouldBe true
+            }
+            Then("equals의 symmetric 테스트") {
+                givenBingsoo.equals(savedBingsoo) shouldBe true
+                savedBingsoo.equals(givenBingsoo) shouldBe true
+
+                givenBingsoo.equals(foundedBingsoo) shouldBe true
+                foundedBingsoo.equals(givenBingsoo) shouldBe true
+
+                savedBingsoo.equals(foundedBingsoo) shouldBe true
+                foundedBingsoo.equals(savedBingsoo) shouldBe true
+            }
+            Then("equals의 transitive 테스트") {
+                givenBingsoo.equals(savedBingsoo) shouldBe true
+                savedBingsoo.equals(foundedBingsoo) shouldBe true
+                foundedBingsoo.equals(givenBingsoo) shouldBe true
+            }
+            Then("equals의 consistent 테스트") {
+                givenBingsoo.equals(foundedBingsoo) shouldBe true
+                savedBingsoo.equals(foundedBingsoo) shouldBe true
+
+                foundedBingsoo.taste = Taste.valueOf("CHOCO")
+
+                givenBingsoo.equals(foundedBingsoo) shouldBe true
+                savedBingsoo.equals(foundedBingsoo) shouldBe true
             }
         }
     }

--- a/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
+++ b/src/test/kotlin/bingsoochef/bingsoochef/bingsoo/persistence/JpaRepositoryTest.kt
@@ -59,10 +59,11 @@ class JpaRepositoryTest @Autowired constructor(
                 givenBingsoo.equals(foundedBingsoo) shouldBe true
                 savedBingsoo.equals(foundedBingsoo) shouldBe true
 
-                foundedBingsoo.taste = Taste.valueOf("CHOCO")
+                foundedBingsoo.updateTaste(Taste.valueOf("CHOCO"))
 
                 givenBingsoo.equals(foundedBingsoo) shouldBe true
                 savedBingsoo.equals(foundedBingsoo) shouldBe true
+                foundedBingsoo.taste shouldBe Taste.valueOf("CHOCO")
             }
         }
     }


### PR DESCRIPTION
### ✨ 작업 내용
- 빙수 생성, 수정, 조회 API를 구현하였습니다.
- JPA 레포지토리 테스트를 수행하였습니다. (JPA Entity의 equals 오버라이딩 동작 확인)
- CustomException과 ExceptionHandler(RestControllerAdvice)를 작성하였습니다.

---

### ✨ 참고 사항
- 로그인 없이 user id를 받아 동작하며, User-Bingsoo 간 매핑이 이루어지지 않습니다.
- HTTP 메시지의 JSON 역직렬화 시 null 값을 대체하는 옵션을 끄고, HttpMessageNotReadableException에 대한 핸들링을 작성하였습니다. 클라이언트에서 파라미터를 누락하였을 때 API가 정상 동작하거나 잘못된 리소스 참조하는 일을 방지하기 위해 껐습니다.
- CustomException들이 많아지면 Enum으로 바꾸고 싶은데... 기회 되면 한 번 의논해보고 싶습니다.

---

### ⏰ 현재 버그
- test 수행 시 Given에서 save 호출한 후 When에서 find 호출한 경우 SQL 쿼리가 두 번 날아갑니다... (예상: 1번) 이후 영속성 테스트 수행 시 다시 확인해보려 합니다.

---

### ✏ Git Close
close #3 